### PR TITLE
fix: make nav dropdown links full-width 

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -104,7 +104,9 @@ export default function RootLayout({
                 <Dropdown.Menu aria-label="Static Actions">
                   {Object.keys(organizationsStore).map((e, i) => (
                     <Dropdown.Item key={i}>
-                      <Link href={`/${e}`}>{e.replace(/-/g, " ")}</Link>
+                      <Link css={{ minWidth: "100%" }} href={`/${e}`}>
+                        {e.replace(/-/g, " ")}
+                      </Link>
                     </Dropdown.Item>
                   ))}
                 </Dropdown.Menu>


### PR DESCRIPTION
Currently, the navigation dropdown's links only cover the text-area, which can make navigation a little funky when you instead just click the empty space around them.

Following [this upstream issue](https://www.github.com/nextui-org/nextui/issues/606#issuecomment-1484482803), I set the min-width of the Link to take up all of the available space that the `Dropdown.Item` reserves.