### PR TITLE
chore: predev scrpt to lint cuz no husky/precommit

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,7 +52,7 @@ export default function RootLayout({
   }, []);
 
   return (
-    <html id="html" lang="en" className={ localStorage.getItem("themeMode") }>
+    <html id="html" lang="en" className={ localStorage.getItem("themeMode") || undefined }>
       <body className={ inter.className }>
         <NextUIProvider>
           <Navbar shouldHideOnScroll className="py-4 px-3.5">

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "semantic"
   ],
   "scripts": {
+    "predev": "next lint --fix",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
I don't think my ` || undefined` did anything. It removes the TS squiggles but i still see this log in my server terminal:

```sh
- error app/layout.tsx (55:42) @ localStorage
- error ReferenceError: localStorage is not defined
    at RootLayout (./app/layout.tsx:58:20)
  53 | 
  54 |   return (
> 55 |     <html id="html" lang="en" className={ localStorage.getItem("themeMode") || undefined }>
     |                                          ^
  56 |       <body className={ inter.className }>
  57 |         <NextUIProvider>
  58 |           <Navbar shouldHideOnScroll className="py-4 px-3.5">
```

I also snuck a `predev` script in there in lieu of Husky or a precommit protocol.. but.. USE THE LINTER!!! ;P lol

Open to suggestions if y'all hate the rules I chose.