### PR TITLE
fix: Better workaround for theme rendering

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
 
   useEffect(() => {
     if (localStorage.getItem("themeMode") !== null) {
-      // intentionall empty
+      // intentionally empty
     } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
       localStorage.setItem("themeMode", "dark");
     } else {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const [theme, setTheme] = useState<string>("");
+  const [theme, setTheme] = useState<string>("invisible");
 
   const invertTheme = (t: string) => (t === "dark" ? "light" : "dark");
 
@@ -33,8 +33,6 @@ export default function RootLayout({
     localStorage.setItem("themeMode", invertTheme(localStorage.themeMode));
     setTheme(localStorage.themeMode);
   };
-
-  const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
     if (localStorage.getItem("themeMode") !== null) {
@@ -46,13 +44,12 @@ export default function RootLayout({
     }
 
     setTheme(localStorage.themeMode);
-    setIsMounted(true);
   }, []);
 
   return (
     <html id="html" lang="en" className={ theme }>
       <body className={ inter.className }>
-        {isMounted ? <NextUIProvider>
+        <NextUIProvider>
           <Navbar shouldHideOnScroll isBordered className="py-2 px-3.5">
             <NavbarBrand>
               <Link href="/">
@@ -96,8 +93,7 @@ export default function RootLayout({
             </NavbarContent>
           </Navbar>
           {children}
-        </NextUIProvider> : null
-        }
+        </NextUIProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
Work smarter, not harder:tm:

Compared to the old strategy of having a state hook which tells the page when to render and when not to, it now abuses the fact that this is a Tailwind CSS website, which means we can use Tailwind CSS classes.

The "invisible" class sets the visibility to hidden, causing the element to not render. As such, the default theme does not render the page.

Once the theme is changed when reading the local storage, the page will render with the new theme selected, causing no where ghosting of the UI when the page changes themes.

There's still the flicker though :/

I didn't make an issue/pr thing because the main issue was fixed and this just cleans everything up.